### PR TITLE
Add csv gem to runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changes
+
+* Add csv gem to runtime dependencies
+
 ### Misc
 
 * Migrate CI from Travis CI to GitHub Actions

--- a/recite_csv.gemspec
+++ b/recite_csv.gemspec
@@ -36,6 +36,8 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.required_ruby_version = ">= 2.4"
 
+  spec.add_dependency "csv"
+
   spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "pry", ">= 0.10.0"
   spec.add_development_dependency "rake", ">= 10.0"


### PR DESCRIPTION
Fix the following warning:
```
warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec.
```